### PR TITLE
Fixing toma_huellas flow.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,8 @@ repos:
     hooks:
     - id: isort
       entry: isort --settings-path setup.cfg
-  - repo: https://github.com/ambv/black
-    rev: 19.10b0
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
     hooks:
     - id: black
       entry: black --config pyproject.toml

--- a/bcncita/cita.py
+++ b/bcncita/cita.py
@@ -285,7 +285,7 @@ def try_cita(context: CustomerProfile, cycles: int = CYCLES):
 
 def toma_huellas_step2(driver: webdriver, context: CustomerProfile):
     try:
-        WebDriverWait(driver, DELAY).until(EC.presence_of_element_located((By.ID, "txtFecha")))
+        WebDriverWait(driver, DELAY).until(EC.presence_of_element_located((By.ID, "txtPaisNac")))
     except TimeoutException:
         logging.error("Timed out waiting for form to load")
         return None
@@ -597,6 +597,7 @@ def select_office(driver: webdriver, context: CustomerProfile):
                     logging.error(e)
                     if context.operation_code == OperationType.RECOGIDA_DE_TARJETA:
                         return None
+            return None
 
         for i in range(5):
             options = list(filter(lambda o: o.get_attribute("value") != "", select.options))

--- a/test.py
+++ b/test.py
@@ -35,7 +35,9 @@ class TestBot(unittest.TestCase):
 
         for province in Province:
             customer = CustomerProfile(
-                **params, province=province, operation_code=OperationType.TOMA_HUELLAS,
+                **params,
+                province=province,
+                operation_code=OperationType.TOMA_HUELLAS,
             )
             with self.assertLogs(None, level=logging.INFO) as logs:
                 try_cita(context=customer, cycles=1)


### PR DESCRIPTION
Fixed: toma_huellas_step2 waiting form to load - no txtFecha field.
Fixed: when offices had been set in the context, the different office still could be selected when none for them were presented on the form