### PR TITLE
Mako 1.1.3 security vulnerability

### DIFF
--- a/bcncita/cita.py
+++ b/bcncita/cita.py
@@ -696,7 +696,7 @@ def office_selection(driver: webdriver, context: CustomerProfile):
             continue
         else:
             logging.info("[Step 2/6] Office selection -> No offices")
-            sleeping_time = rnd.randint(5,20)
+            sleeping_time = random.randint(5,20)
             print('Wait {} sec'.format(sleeping_time))
             time.sleep(sleeping_time) # Wait "sleeping_time" seconds between cycles if no office found or else will be temporarily blocked (for ~5m)
             return None

--- a/bcncita/cita.py
+++ b/bcncita/cita.py
@@ -285,10 +285,16 @@ def start_with(driver: webdriver, context: CustomerProfile, cycles: int = CYCLES
             result = cycle_cita(driver, context, fast_forward_url, fast_forward_url2)
         except KeyboardInterrupt:
             raise
+            print(f"Wait 5 minutes after Cycle {i+1}", cycles)
+            time.sleep(300) # Wait 5 minutes (5*60 sec) within each retry or else your IP will be bloked.
         except TimeoutException:
             logging.error("Timeout exception")
+            print(f"Wait 5 minutes after Cycle {i+1}", cycles)
+            time.sleep(300) # Wait 5 minutes, same
         except Exception as e:
             logging.error(f"SMTH BROKEN: {e}")
+            print(f"Wait 5 minutes after Cycle {i+1}", cycles)
+            time.sleep(300) # Wait 5 minutes, same.
             continue
 
         if result:
@@ -690,6 +696,9 @@ def office_selection(driver: webdriver, context: CustomerProfile):
             continue
         else:
             logging.info("[Step 2/6] Office selection -> No offices")
+            sleeping_time = rnd.randint(5,20)
+            print('Wait {} sec'.format(sleeping_time))
+            time.sleep(sleeping_time) # Wait "sleeping_time" seconds between cycles if no office found or else will be temporarily blocked (for ~5m)
             return None
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 selenium==4.1.3
-Mako==1.1.3
+Mako==1.2.2
 anticaptchaofficial==1.0.31
 requests==2.26.0
 backoff==2.1.2


### PR DESCRIPTION
Hello,

Thanks for this repo.

My dependabot informed me that Mako 1.1.3 has a security vulnerability that is fixed from version 1.2.2 and onwards.

You might want to update the requirements.txt accordingly and also add the dependabot automation on your repo as it's very helpful.

Cheers!